### PR TITLE
Fix therapist profile creation error

### DIFF
--- a/src/hooks/useTherapistRegistration.ts
+++ b/src/hooks/useTherapistRegistration.ts
@@ -132,6 +132,28 @@ export function useTherapistRegistration() {
         return;
       }
 
+      // Create user profile first
+      const { error: profileError } = await supabase
+        .from('profiles')
+        .insert({
+          id: authData.user.id,
+          email: formData.email,
+          first_name: formData.firstName,
+          last_name: formData.lastName,
+          phone: formData.phone,
+          date_of_birth: formData.dateOfBirth,
+          role: 'therapist'
+        });
+
+      if (profileError) {
+        toast({
+          title: "Error",
+          description: "Failed to create user profile",
+          variant: "destructive"
+        });
+        return;
+      }
+
       // Create therapist profile
       const { error: therapistError } = await supabase
         .from('therapists')

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -240,6 +240,7 @@ export type Database = {
           bio: string
           certifications: string[] | null
           created_at: string | null
+          documents: Json[] | null
           education: string
           hourly_rate: number
           id: string
@@ -257,6 +258,7 @@ export type Database = {
           bio?: string
           certifications?: string[] | null
           created_at?: string | null
+          documents?: Json[] | null
           education?: string
           hourly_rate?: number
           id?: string
@@ -274,6 +276,7 @@ export type Database = {
           bio?: string
           certifications?: string[] | null
           created_at?: string | null
+          documents?: Json[] | null
           education?: string
           hourly_rate?: number
           id?: string


### PR DESCRIPTION
Fix "failed to create therapist profile" error by updating database types and ensuring explicit profile creation.

The error occurred because the `therapists` table had a foreign key constraint to `profiles.id`, but no `profiles` record was being created. Additionally, the `documents` field was missing from the `therapists` table TypeScript types, leading to insertion failures.

---
<a href="https://cursor.com/background-agent?bcId=bc-1b51f5c3-a253-499e-99d7-6970a2559982">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1b51f5c3-a253-499e-99d7-6970a2559982">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

